### PR TITLE
Count iOS safari-based browsers as safari

### DIFF
--- a/src/caniuse-parser.js
+++ b/src/caniuse-parser.js
@@ -216,11 +216,9 @@ function handleDataFeed(entries) {
       (os == "iOS" || os == "iPad" || os == "iPhone" || os == "iPod")
     ) {
       browser = "iOS Safari";
-    } else if (
-      browser == "Mozilla Compatible Agent" &&
-      (os == "iPad" || os == "iPhone" || os == "iPod")
-    ) {
-      browser = "iOS Safari"; //browser = 'iOS app';
+    } else if (os == "iPad" || os == "iPhone" || os == "iPod") {
+      // all apps on ios must use safari engine by apple rules
+      browser = "iOS Safari";
     } else if (browser == "Opera" && (isMobile || os == "(not set)")) {
       browser = "Opera Mobile";
     } else if (browser == "Safari (in-app)") {

--- a/src/caniuse-parser.js
+++ b/src/caniuse-parser.js
@@ -211,11 +211,11 @@ function handleDataFeed(entries) {
     var isMobile = entry[4] == "Yes";
     var pageviews = +entry[5];
 
-    if (os == "iOS" || os == "iPad" || os == "iPhone" || os == "iPod") {
+    if (browser == "Opera" && (isMobile || os == "(not set)")) {
+      browser = "Opera Mobile";
+    } else if (os == "iOS" || os == "iPad" || os == "iPhone" || os == "iPod") {
       // all apps on ios must use safari engine by apple rules
       browser = "iOS Safari";
-    } else if (browser == "Opera" && (isMobile || os == "(not set)")) {
-      browser = "Opera Mobile";
     } else if (browser == "Safari (in-app)") {
       browser = "iOS Safari";
     } else if (browser == "BlackBerry") {

--- a/src/caniuse-parser.js
+++ b/src/caniuse-parser.js
@@ -211,12 +211,7 @@ function handleDataFeed(entries) {
     var isMobile = entry[4] == "Yes";
     var pageviews = +entry[5];
 
-    if (
-      (browser == "Safari" || browser == "Chrome") &&
-      (os == "iOS" || os == "iPad" || os == "iPhone" || os == "iPod")
-    ) {
-      browser = "iOS Safari";
-    } else if (os == "iPad" || os == "iPhone" || os == "iPod") {
+    if (os == "iOS" || os == "iPad" || os == "iPhone" || os == "iPod") {
       // all apps on ios must use safari engine by apple rules
       browser = "iOS Safari";
     } else if (browser == "Opera" && (isMobile || os == "(not set)")) {


### PR DESCRIPTION
All apps on iOS must use safari engine by apple rules.
This PR will make safari-based iOS browsers count as safari thus improving stats